### PR TITLE
lang="nl-NL"

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,6 +2,7 @@
 title: Project OpenZaak Samenwerken
 description: Een overzicht van het project OpenZaak Samenwerken
 url: "" # the base hostname & protocol for your site
+lang: "nl-NL"
 
 # Build settings
 markdown: kramdown


### PR DESCRIPTION
Without setting the language, the default is "en-US", which is clearly wrong.